### PR TITLE
remove wrong information about the docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ function process_redirect($authorization_code, $state) {
 }
 ```
 
-You can find more documentation in the `doc/` folder.
-
 Demos
 -----
 In this repository you can also have a look at a simple console (console_demo.php) and web demo (web_demo/).


### PR DESCRIPTION
there is no docs/ folder in the git project

The user should refer to the figo documentation: http://docs.figo.io/

The URL is already listed in the README.md file