### PR TITLE
Fixed error response handling on 400 response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 composer.phar
 composer.lock
 vendor/

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -23,7 +23,6 @@
 
 namespace figo;
 
-
 /**
  * HTTPS request class with certificate authentication and enhanced error handling
  */
@@ -32,11 +31,12 @@ class HttpsRequest {
     /**
      * Send client request and return server response.
      *
-     * @param string the URL path on the server
-     * @param string the HTTP body
-     * @param string the HTTP method
-     * @param array additional HTTP headers
+     * @param string $path the URL path on the server
+     * @param string $data the HTTP body
+     * @param string $method the HTTP method
+     * @param array $headers additional HTTP headers
      * @return array JSON response
+     * @throws Exception
      */
     public function request($path, $data, $method, array $headers) {
         // Open socket.
@@ -101,7 +101,7 @@ class HttpsRequest {
              if (is_null($err)) {
                  throw new Exception("json_error", "Cannot decode JSON object.");
              } else {
-                 throw new Exception($err["error"], $err["error_description"]);
+                 throw new Exception($err["error"]["code"], $err["error"]["description"]);
              }
         } elseif ($code === 401) {
             throw new Exception("unauthorized", "Missing, invalid or expired access token.");


### PR DESCRIPTION
The error response of the API looks like this:

    Array
    (
        [status] => 400
        [error] => Array
            (
                [code] => 30400
                [group] =>
                [name] => HTTPClientError
                [message] => invalid_grant
                [data] => Array
                    (
                    )

                [description] => Already exchanged authorization code.
            )
    )

When creating the exception the code tries this:
    
    throw new Exception($err["error"], $err["error_description"]);

which is wrong. I've changed it to:

    throw new Exception($err["error"]["code"], $err["error"]["description"]);

Or maybe the response of the server for the 400 responses is wrong. You have to decide :)