### PR TITLE
Add native client login and bank account setup

### DIFF
--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -150,6 +150,20 @@ class Connection {
         return $this->query_api("/auth/token", $data);
     }
 
+    /**
+     * Native client login with figo Account credentials.
+     *
+     * @param string the figo Account email address
+     * @param string the figo Account password
+     * @param string scope of data access to ask the user for, e.g. <code>accounts=ro</code>
+     * @return array associative array with the keys <code>access_token</code>, <code>refresh_token</code>
+     *         and <code>expires</code>, as documented in the figo Connect API specification
+     */
+    public function native_client_login($username, $password, $scope = null) {
+        $data = array("grant_type" => "password", "username" => $username, "password" => $password, "scope" => $scope);
+        return $this->query_api("/auth/token", $data);
+    }
+
 
     /**
      * Revoke refresh token or access token.

--- a/figo/Session.php
+++ b/figo/Session.php
@@ -138,6 +138,27 @@ class Session {
     }
 
 
+    /**
+     * Set up a new bank account
+     *
+     * @param string Bank code or IBAN (which the bank code is extracted from)
+     * @param string List of login credential strings. They must be in the same order as in the credentials list from the login settings
+     * @param array $options Optional Options:
+     *           - `country` - Two-letter country code. Valid values: de
+     *           - `save_pin` - This flag indicates whether the user has chosen to save the PIN on the figo Connect server
+     *           - `disable_first_sync` - This flag indicates whether the initial sync of the transactions and balances of the newly created accounts should be omitted
+     *           - `sync_tasks` - List of additional information to be fetched from the bank. Possible values are: standingOrders
+     *           - `redirect_uri` - The user will be redirect to this URI after completing the account setup
+     */
+    public function setup_bank_account($bank_code_or_iban, $credentials, $options) {
+        if (is_numeric($bank_code_or_iban)) {
+            $options["bank_code"] = (string) $bank_code_or_iban;
+        } else {
+            $options["iban"] = $bank_code_or_iban;
+        }
+        $options["credentials"] = $credentials;
+        return $this->query_api("/rest/accounts", $options, "POST");
+    }
 
     /**
      * Retrieve list of accounts

--- a/test/FigoTest.php
+++ b/test/FigoTest.php
@@ -27,7 +27,7 @@ use figo\Notification;
 use figo\Payment;
 
 
-class FigoTest extends PHPUnit_Framework_TestCase {
+class SessionTest extends PHPUnit_Framework_TestCase {
 
     protected $sut;
 
@@ -167,5 +167,35 @@ class FigoTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(100.00, $standing_order[0]->amount);
     }
 
+    public function test_setup_bank_account() {
+        $response = $this->sut->setup_bank_account(
+            "90090042", ["demo", "demo"],
+            ["country" => "de", "save_pin" => true]
+        );
+        $this->assertTrue(isset($response["task_token"]));
+    }
+
+}
+
+
+class ConnectionTest extends PHPUnit_Framework_TestCase {
+
+    protected $sut;
+
+    protected function setUp() {
+        $this->sut = new Connection("CaESKmC8MAhNpDe5rvmWnSkRE_7pkkVIIgMwclgzGcQY", "STdzfv0GXtEj_bwYn7AgCVszN1kKq5BdgEIKOM_fzybQ");
+    }
+
+    public function test_native_login() {
+        $response = $this->sut->native_client_login("demo@figo.me", "demo1234");
+        $access_token = $response["access_token"];
+        $session = new Session($access_token);
+        try {
+            $this->assertEquals([], $session->get_accounts());
+        } finally {
+            $session->remove_user();
+        }
+
+    }
 }
 ?>


### PR DESCRIPTION
Implement new methods "native_client_login" and "setup_bank_account".
The unit tests currently fail for both methods because
A) native client login is not supported by the demo@figo.me account and
B) the demo access token does not have modification permissions.
