### PR TITLE
Logging, API call additions,support for custom api endpoint & fingerprints, User-Agent Adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   },
   "require": {
-    "php": ">=5.3.2"
+    "php": ">=5.3.2",
+    "psr/log": "^1.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*",

--- a/figo/Config.php
+++ b/figo/Config.php
@@ -35,6 +35,14 @@ class Config {
     /** @var string figo Connect SSL/TLS certificate fingerprints */
     public static $VALID_FINGERPRINTS = array("38:AE:4A:32:6F:16:EA:15:81:33:8B:B0:D8:E4:A6:35:E7:27:F1:07",
                                               "DB:E2:E9:15:8F:C9:90:30:84:FE:36:CA:A6:11:38:D8:5A:20:5D:93");
+    /**
+     * @var string User agent used for API requests
+     */
+    public static $USER_AGENT = 'php_figo';
+    /**
+     * @var string Version of this SDK, used in user agent for API requests
+     */
+    public static $SDK_VERSION = 'v1.1.4';
 }
 
 ?>

--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -261,6 +261,31 @@ class Connection {
         return $response["recovery_password"];
     }
 
+    /**
+     * credential login
+     *
+     * @param $username
+     * @param $password
+     * @param null $device_name
+     * @param null $device_type
+     * @param null $device_udid
+     * @param null $scope
+     * @return array
+     */
+    public function credential_login($username, $password, $device_name = null, $device_type = null, $device_udid = null, $scope = null)
+    {
+        $options = [ "grant_type" => "password", "username" => $username, "password" => $password ];
+        if ($device_name)
+            $options["device_name"] = $device_name;
+        if ($device_type)
+            $options["device_type"] = $device_type;
+        if ($device_udid)
+            $options["device_udid"] = $device_udid;
+        if ($scope)
+            $options["scope"] = $scope;
+        return $this->query_api("/auth/token", $options, "POST");
+    }
+
 
 }
 

--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -23,12 +23,17 @@
 
 namespace figo;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Represents a non user-bound connection to the figo Connect API
  */
 class Connection {
-
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
     private $client_id;
     private $client_secret;
     private $redirect_uri;
@@ -44,6 +49,17 @@ class Connection {
         $this->client_id = $client_id;
         $this->client_secret = $client_secret;
         $this->redirect_uri = $redirect_uri;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * Set Logger
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -69,7 +85,7 @@ class Connection {
                         "Content-Type"   => $content_type,
                          "Content-Length" => strlen($data));
 
-        $request = new HttpsRequest();
+        $request = new HttpsRequest($this->logger);
         return $request->request($path, $data, $method, $headers);
     }
 

--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -37,6 +37,14 @@ class Connection {
     private $client_id;
     private $client_secret;
     private $redirect_uri;
+    /**
+     * @var null API endpoint
+     */
+    private $apiEndpoint;
+    /**
+     * @var array Fingerprints for API endpoint
+     */
+    private $fingerprints;
 
     /**
      * Constructor
@@ -44,12 +52,26 @@ class Connection {
      * @param string the client ID
      * @param string the client secret
      * @param string redirect URI
+     * @param string $apiEndpoint Custom API endpoint
+     * @param array $fingerprints Fingerprints for custom API endpoint
      */
-    public function __construct($client_id, $client_secret, $redirect_uri = null) {
+    public function __construct($client_id, $client_secret, $redirect_uri = null, $apiEndpoint = null, array $fingerprints = null) {
+        // set default values
+        $this->logger = new NullLogger();
+        $this->apiEndpoint = Config::$API_ENDPOINT;
+        $this->fingerprints = Config::$VALID_FINGERPRINTS;
+
         $this->client_id = $client_id;
         $this->client_secret = $client_secret;
         $this->redirect_uri = $redirect_uri;
-        $this->logger = new NullLogger();
+
+        if ($apiEndpoint) {
+            $this->apiEndpoint = $apiEndpoint;
+        }
+
+        if ($fingerprints) {
+            $this->fingerprints = $fingerprints;
+        }
     }
 
     /**
@@ -85,7 +107,7 @@ class Connection {
                         "Content-Type"   => $content_type,
                          "Content-Length" => strlen($data));
 
-        $request = new HttpsRequest($this->logger);
+        $request = new HttpsRequest($this->apiEndpoint, $this->fingerprints, $this->logger);
         return $request->request($path, $data, $method, $headers);
     }
 

--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -125,10 +125,17 @@ class Connection {
      *
      * @return array
      */
-    public function get_supported_payment_services($service=null) {
+    public function get_supported_payment_services($service=null, $countryCode = null) {
         switch ($service) {
             case "banks":
-                $response = $this->query_api("/catalog/banks", null, "GET");
+
+                $url = '/catalog/banks';
+
+                if($countryCode) {
+                    $url = $url . '/' . $countryCode;
+                }
+
+                $response = $this->query_api($url, null, "GET");
                 break;
             case "services":
                 $response = $this->query_api("/catalog/services", null, "GET");

--- a/figo/Exception.php
+++ b/figo/Exception.php
@@ -44,7 +44,7 @@ class Exception extends \Exception {
     public function __construct($error, $error_description) {
         $this->error = $error;
         $this->error_description = $error_description;
-        parent::__construct($error_description);
+        parent::__construct($error . ', ' . $error_description);
     }
 
     /**

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -78,7 +78,7 @@ class HttpsRequest {
         // Setup common HTTP headers.
         $headers["Host"] = Config::$API_ENDPOINT;
         $headers["Accept"] = "application/json";
-        $headers["User-Agent"] = "php-figo";
+        $headers["User-Agent"] = Config::$USER_AGENT . '/' . Config::$SDK_VERSION;
         $headers["Connection"] = "close";
 
         // Send client request.

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -158,7 +158,6 @@ class HttpsRequest {
                 return null;
             } elseif ($code >= 400 && $code < 500) {
                 throw new Exception($obj["error"]["name"] .":". $obj["error"]["message"]." (Error-Code: ".$obj["error"]["code"].")" , $obj["error"]["description"]);
-                //throw new Exception("foo", "bar");
             } elseif ($code === 503) {
                 throw new Exception("service_unavailable", "Exceeded rate limit.");
             } else {

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -145,33 +145,25 @@ class HttpsRequest {
         if ($code >= 200 && $code < 300) {
             if (strlen($body) === 0) {
                 return array();
-            } else {
-                $obj = json_decode($body, true);
-                if (is_null($obj)) {
-                    throw new Exception("json_error", "Cannot decode JSON object.");
-                } else {
-                    return $obj;
-                }
-             }
-        } elseif ($code === 400) {
-             $err = json_decode($body, true);
-             if (is_null($err)) {
-                 throw new Exception("json_error", "Cannot decode JSON object.");
-             } else {
-                 throw new Exception($err["error"]["name"] .":". $err["error"]["message"]." (Error-Code: ".$err["error"]["code"].")" , $err["error"]["description"]);
-             }
-        } elseif ($code === 401) {
-            throw new Exception("unauthorized", "Missing, invalid or expired access token.");
-        } elseif ($code === 403) {
-            throw new Exception("forbidden", "Insufficient permission.");
-        } elseif ($code === 404) {
-            return null;
-        } elseif ($code === 405) {
-            throw new Exception("method_not_allowed", "Unexpected request method.");
-        } elseif ($code === 503) {
-            throw new Exception("service_unavailable", "Exceeded rate limit.");
+            }
+        }
+
+        $obj = json_decode($body, true);
+        if (is_null($obj)) {
+            throw new Exception("json_error", "Cannot decode JSON object.");
         } else {
-            throw new Exception("internal_server_error", "We are very sorry, but something went wrong.");
+            if ($code >= 200 && $code < 300) {
+                return $obj;
+            } elseif ($code === 404) {
+                return null;
+            } elseif ($code >= 400 && $code < 500) {
+                throw new Exception($obj["error"]["name"] .":". $obj["error"]["message"]." (Error-Code: ".$obj["error"]["code"].")" , $obj["error"]["description"]);
+                //throw new Exception("foo", "bar");
+            } elseif ($code === 503) {
+                throw new Exception("service_unavailable", "Exceeded rate limit.");
+            } else {
+                throw new Exception("internal_server_error", "We are very sorry, but something went wrong.");
+            }
         }
     }
 }

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -119,11 +119,11 @@ class HttpsRequest {
             )
         );
 
-        if ($path === '/task/progress') {
+        if (strpos($path, '/task/progress') !== false) {
             // when on /task/progress
             if ($code >= 200 && $code < 400) {
-                $data = array_merge($loggingData, array('task_id' => $responseArray['task_id']));
-                if($responseArray['is_erronous']) {
+                $data = array_merge($loggingData, array('task_id' => explode('/task/progress?id=', $path)[1]));
+                if($responseArray['is_erroneous']) {
                     $this->logger->info('API request to /task/progress', $data);
                 } else {
                     $this->logger->debug('API request to /task/progress', $data);

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -122,7 +122,7 @@ class HttpsRequest {
         if ($path === '/task/progress') {
             // when on /task/progress
             if ($code >= 200 && $code < 400) {
-                $data = array_merge($loggingData, ['task_id' => $responseArray['task_id']]);
+                $data = array_merge($loggingData, array('task_id' => $responseArray['task_id']));
                 if($responseArray['is_erronous']) {
                     $this->logger->info('API request to /task/progress', $data);
                 } else {

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -111,18 +111,22 @@ class HttpsRequest {
 
         if ($path === '/task/progress') {
             // when on /task/progress
-            $data = array_merge($loggingData, ['task_id' => $responseArray['task_id']]);
-            if($responseArray['is_erronous']) {
-                $this->logger->info('API Request to /task/progress', $data);
+            if ($code >= 200 && $code < 400) {
+                $data = array_merge($loggingData, ['task_id' => $responseArray['task_id']]);
+                if($responseArray['is_erronous']) {
+                    $this->logger->info('API request to /task/progress', $data);
+                } else {
+                    $this->logger->debug('API request to /task/progress', $data);
+                }
             } else {
-                $this->logger->debug('API Request to /task/progress', $data);
+                $this->logger->info('API request to /task/progress failed', $loggingData);
             }
         } else {
             // when not on /task/progress
             if ($code >= 200 && $code < 400) {
-                $this->logger->debug('API Request', $loggingData);
+                $this->logger->debug('API request', $loggingData);
             } else {
-                $this->logger->info('API Request Failed', $loggingData);
+                $this->logger->info('API request failed', $loggingData);
             }
         }
 

--- a/figo/Session.php
+++ b/figo/Session.php
@@ -205,6 +205,29 @@ class Session {
     }
 
     /**
+     * Add an account
+     *
+     * @param $country
+     * @param $credentials
+     * @param $bank_code
+     * @param $iban
+     * @param $save_pin
+     * @return Account|null
+     */
+    public function add_account($country, $credentials, $bank_code, $iban, $save_pin)
+    {
+        $data = ["country" => $country, "credentials" => $credentials];
+        if ($iban) {
+            $data["iban"] = $iban;
+        } else if ($bank_code) {
+            $data["bank_code"] = $bank_code;
+        }
+        $data["save_pin"] = (is_bool($save_pin)) ? $save_pin : false;
+        $response = $this->query_api("/rest/accounts", $data, "POST");
+        return (is_null($response) ? null : new Account($this, $response));
+    }
+
+    /**
      * Modify an account
      *
      * @param Account the modified account to be saved

--- a/figo/Session.php
+++ b/figo/Session.php
@@ -23,12 +23,17 @@
 
 namespace figo;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Represents a user-bound connection to the figo Connect API and allows access to the user's data
  */
 class Session {
-
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
     private $access_token;
 
     /**
@@ -38,6 +43,17 @@ class Session {
      */
     public function __construct($access_token) {
         $this->access_token = $access_token;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * Set Logger
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -55,7 +71,8 @@ class Session {
                          "Content-Type"   => "application/json",
                          "Content-Length" => strlen($data));
 
-        $request = new HttpsRequest();
+        $request = new HttpsRequest($this->logger);
+
         return $request->request($path, $data, $method, $headers);
     }
 

--- a/figo/Session.php
+++ b/figo/Session.php
@@ -216,7 +216,7 @@ class Session {
      */
     public function add_account($country, $credentials, $bank_code, $iban, $save_pin)
     {
-        $data = ["country" => $country, "credentials" => $credentials];
+        $data = array("country" => $country, "credentials" => $credentials);
         if ($iban) {
             $data["iban"] = $iban;
         } else if ($bank_code) {

--- a/figo/Session.php
+++ b/figo/Session.php
@@ -35,15 +35,37 @@ class Session {
      */
     protected $logger;
     private $access_token;
+    /**
+     * @var null API endpoint
+     */
+    private $apiEndpoint;
+    /**
+     * @var array Fingerprints for API endpoint
+     */
+    private $fingerprints;
 
     /**
      * Constructor
      *
      * @param string the access token
+     * @param string $apiEndpoint Custom API endpoint
+     * @param array $fingerprints Fingerprints for custom API endpoint
      */
-    public function __construct($access_token) {
-        $this->access_token = $access_token;
+    public function __construct($access_token, $apiEndpoint = null, array $fingerprints = null) {
+        // set default values
         $this->logger = new NullLogger();
+        $this->apiEndpoint = Config::$API_ENDPOINT;
+        $this->fingerprints = Config::$VALID_FINGERPRINTS;
+
+        $this->access_token = $access_token;
+
+        if ($apiEndpoint) {
+            $this->apiEndpoint = $apiEndpoint;
+        }
+
+        if ($fingerprints) {
+            $this->fingerprints = $fingerprints;
+        }
     }
 
     /**
@@ -71,7 +93,7 @@ class Session {
                          "Content-Type"   => "application/json",
                          "Content-Length" => strlen($data));
 
-        $request = new HttpsRequest($this->logger);
+        $request = new HttpsRequest($this->apiEndpoint, $this->fingerprints, $this->logger);
 
         return $request->request($path, $data, $method, $headers);
     }


### PR DESCRIPTION
# Logging

I just added support for the `psr/log` interface so the users are able to inject the logger of their choice. For example [monolog/monolog](https://github.com/Seldaek/monolog):

```
use figo\Session;
use Monolog\Handler\StreamHandler;
use Monolog\Logger;

$logger = new \Monolog\Logger('logger');
$logger->pushHandler(new StreamHandler('php://stdout', Logger::DEBUG));

$session = new Session("...");
$session->setLogger($logger);
```

I passed all available data to the logger in the following format. How it is handled (e.g. transformed into another format) is up to the passed in logger.

```
$loggingData = array(
            'path' => $path,
            'data' => $data,
            'method' => $method,
            'headers' => $headers,
            'response' => array(
                'status' => $code,
                'body' => $responseArray
            )
        );
```

# Addition to API Endpoints

The requested API endpoints were already implemented, so I just had to add support for CountryCodes on the `/catalog/banks` endpoint.

Usage:

```
$banks = $connection->get_supported_payment_services('banks', 'DE');
```

# Custom API Endpoint and Fingerprints

I just added two new optional parameters to the constructor of the `Connection` and `Session` classes. 

Usage:

```
$session = new Session('<token>', 'staging.figo.me', array('<fingerprint>', '<fingerprint>'));
```

```
$connection = new Connection('<client_id>', '<client_secret>', null, 'staging.figo.me', array('<fingerprint>', '<fingerprint>'));
```

It's up to the user to provide valid information.

# User Agent Adjustments

The `Config` class got two new static variables, `$USER_AGENT` and `$SDK_VERSION` which will be used for the User-Agent sent with each request. The `$SDK_VERSION` variable needs to be adjusted with each release of this SDK.