### PR TITLE
Get Travis back to work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ php:
   - 7.0
   - 7.1
 before_script: composer install
+script: vendor/bin/phpunit


### PR DESCRIPTION
It looks like Travis uses it's own phpunit version which is already the latest and not compatible with <PHP7 anymore. Using our own installed version should (hopefully) work.