### PR TITLE
Add support for categories in transactions

### DIFF
--- a/figo/Base.php
+++ b/figo/Base.php
@@ -50,6 +50,11 @@ class Base {
                 $this->$key = new AccountBalance($session, $value);
             } elseif (substr($key, -5) === "_date" || substr($key, -10) === "_timestamp") {
                 $this->$key = new \DateTime($value, new \DateTimeZone("UTC"));
+            } elseif ($key === "categories" && is_array($value)) {
+                $this->$key = [];
+                foreach ($value as $category) {
+                    $this->$key[] = new Category($session, $category);
+                }
             } else {
                 $this->$key = $value;
             }

--- a/figo/Category.php
+++ b/figo/Category.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Copyright (c) 2013 figo GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace figo;
+
+
+/**
+ * Object representing one category
+ */
+class Category extends Base {
+
+    /** @var int|null ID of parent category */
+    public $parent_id;
+
+    /** @var int ID of category */
+    public $id;
+
+    /** @var string Name of the category */
+    public $name;
+}

--- a/figo/Transaction.php
+++ b/figo/Transaction.php
@@ -84,6 +84,9 @@ class Transaction extends Base {
 
     /** @var array Contains additional information for PayPal transactions */
     public $additional_info;
+
+    /** @var  Category[]*/
+    public $categories;
 }
 
 ?>


### PR DESCRIPTION
Not much of a change. If categories are available in the response data, they will be parsed into Category objects and assigned to the Transaction object.