### PR TITLE
Update remote socket adress in HttpsRequest.php

### DIFF
--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -66,7 +66,7 @@ class HttpsRequest {
         stream_context_set_option($context, "ssl", "verify_peer", true);
         stream_context_set_option($context, "ssl", "capture_peer_cert", true);
 
-        $fp = stream_socket_client("tlsv1.2://". $this->apiEndpoint .":443/", $errno, $errstr, 60, STREAM_CLIENT_CONNECT, $context);
+        $fp = stream_socket_client("tlsv1.2://". $this->apiEndpoint .":443", $errno, $errstr, 60, STREAM_CLIENT_CONNECT, $context);
         if (!$fp) {
             throw new Exception("socket_error", $errstr);
         }


### PR DESCRIPTION
PHP 7.0.18 throw this error:

```
Warning: stream_socket_client(): unable to connect to tlsv1.2://api.figo.me:443/ 
(Failed to parse address "api.figo.me:443/") in: /vendor/figo/figo/figo/HttpsRequest.php:69
```