### PR TITLE
Support i18n on catalog requests

### DIFF
--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -94,7 +94,7 @@ class Connection {
      *
      * @return array JSON response
      */
-    public function query_api($path, array $data = null, $method='POST', $encode='http_build_query') {
+    public function query_api($path, array $data = null, $method='POST', $encode='http_build_query', $language = 'de') {
         if ($encode != 'http_build_query') {
             $data = is_null($data) ? "" : json_encode($data);
             $content_type = "application/json";
@@ -108,7 +108,7 @@ class Connection {
                          "Content-Length" => strlen($data));
 
         $request = new HttpsRequest($this->apiEndpoint, $this->fingerprints, $this->logger);
-        return $request->request($path, $data, $method, $headers);
+        return $request->request($path, $data, $method, $headers, $language);
     }
 
     /**
@@ -147,7 +147,7 @@ class Connection {
      *
      * @return array
      */
-    public function get_supported_payment_services($service=null, $countryCode = null) {
+    public function get_supported_payment_services($service=null, $countryCode = null, $language = 'de') {
         switch ($service) {
             case "banks":
 
@@ -157,13 +157,13 @@ class Connection {
                     $url = $url . '/' . $countryCode;
                 }
 
-                $response = $this->query_api($url, null, "GET");
+                $response = $this->query_api($url, null, "GET", "http_build_query", $language);
                 break;
             case "services":
-                $response = $this->query_api("/catalog/services", null, "GET");
+                $response = $this->query_api("/catalog/services", null, "GET", "http_build_query", $language);
                 break;
             default:
-                $response = $this->query_api("/catalog", null, "GET");
+                $response = $this->query_api("/catalog", null, "GET", "http_build_query", $language);
         }
         return $response;
     }

--- a/figo/Exception.php
+++ b/figo/Exception.php
@@ -53,7 +53,7 @@ class Exception extends \Exception {
      * @return string the error description
      */
     public function __toString() {
-        return $this->error_description."\n";
+        return $this->error . ', ' . $this->error_description."\n";
     }
 }
 

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -147,7 +147,7 @@ class HttpsRequest {
 
         if ($code >= 400 && $code < 500) {
             $this->logFailedRequest($path, $responseArray, $loggingData);
-            throw new Exception($responseArray["error"]["name"] .":". $responseArray["error"]["message"]." (Error-Code: ".$responseArray["error"]["code"].")" , $responseArray["error"]["description"]);
+            throw new Exception($responseArray["error"]["name"] .": ". $responseArray["error"]["message"]." (Status: ".$responseArray["status"].")" , $responseArray["error"]["description"]);
         }
 
         if ($code === 503) {

--- a/figo/HttpsRequest.php
+++ b/figo/HttpsRequest.php
@@ -59,7 +59,7 @@ class HttpsRequest {
      * @return array JSON response
      * @throws Exception
      */
-    public function request($path, $data, $method, array $headers) {
+    public function request($path, $data, $method, array $headers, $language = 'de') {
         // Open socket.
         $context = stream_context_create();
         stream_context_set_option($context, "ssl", "cafile", dirname(__FILE__).DIRECTORY_SEPARATOR."ca-bundle.crt");
@@ -90,6 +90,7 @@ class HttpsRequest {
         $headers["Accept"] = "application/json";
         $headers["User-Agent"] = Config::$USER_AGENT . '/' . Config::$SDK_VERSION;
         $headers["Connection"] = "close";
+        $headers["accept-language"] = $language;
 
         // Send client request.
         $header = "";

--- a/test/FigoTest.php
+++ b/test/FigoTest.php
@@ -180,6 +180,7 @@ class SessionTest extends PHPUnit_Framework_TestCase {
 
 class ConnectionTest extends PHPUnit_Framework_TestCase {
 
+    /** @var  Connection */
     protected $sut;
 
     protected function setUp() {
@@ -209,6 +210,29 @@ class ConnectionTest extends PHPUnit_Framework_TestCase {
         $response = $this->sut->credential_login('php.sdk.testing@figo.io', 'phpsdk');
         $this->assertNotEmpty($response);
         $this->assertNotNull($response['access_token']);
+    }
+
+    public function test_catalog_language_is_german_by_default()
+    {
+        $result = $this->sut->get_supported_payment_services();
+
+        $this->assertEquals('de', $result['banks'][0]['language']['current_language']);
+    }
+
+    public function test_catalog_language_can_be_set_to_english()
+    {
+        $result = $this->sut->get_supported_payment_services(null, null, 'en');
+
+        $this->assertEquals('en', $result['banks'][0]['language']['current_language']);
+    }
+
+    public function test_catalog_throws_exception_on_unsupported_language()
+    {
+        $this->setExpectedException(
+            \figo\Exception::class, 'Not Acceptable: Unsupported language (Status: 406), '
+        );
+
+        $this->sut->get_supported_payment_services(null, null, 'fr');
     }
 }
 ?>

--- a/test/FigoTest.php
+++ b/test/FigoTest.php
@@ -183,7 +183,13 @@ class ConnectionTest extends PHPUnit_Framework_TestCase {
     protected $sut;
 
     protected function setUp() {
-        $this->sut = new Connection("CaESKmC8MAhNpDe5rvmWnSkRE_7pkkVIIgMwclgzGcQY", "STdzfv0GXtEj_bwYn7AgCVszN1kKq5BdgEIKOM_fzybQ");
+        $this->sut = new Connection(
+            getenv('FIGO_CLIENT_ID'),
+            getenv('FIGO_CLIENT_SECRET'),
+            "http://my-domain.org/redirect-url",
+            getenv('FIGO_API_ENDPOINT'),
+            explode(',', getenv('FIGO_SSL_FINGERPRINT'))
+        );
     }
 
     public function test_native_login() {
@@ -196,6 +202,13 @@ class ConnectionTest extends PHPUnit_Framework_TestCase {
             $session->remove_user();
         }
 
+    }
+
+    public function test_credentials_login()
+    {
+        $response = $this->sut->credential_login('php.sdk.testing@figo.io', 'phpsdk');
+        $this->assertNotEmpty($response);
+        $this->assertNotNull($response['access_token']);
     }
 }
 ?>


### PR DESCRIPTION
I was not sure if the language parameter should be passed to the call or set on the Connection object. I decided that it makes more sense to set in on the call.

I wrote tests for all cases (default, override, not supported). I used the branch from #40 as base so #40 should be merged first.