### PR TITLE
only set content-type header if there is content

### DIFF
--- a/figo/Connection.php
+++ b/figo/Connection.php
@@ -107,8 +107,11 @@ class Connection {
         }
 
         $headers = array("Authorization"  => "Basic ".base64_encode($this->client_id.":".$this->client_secret),
-                        "Content-Type"   => $content_type,
                          "Content-Length" => strlen($data));
+        if (strlen($data) > 0) {
+            $headers["Content-Type"] = $content_type;
+
+        }
 
         $request = new HttpsRequest($this->apiUrl['host'], $this->fingerprints, $this->logger);
         $path = $this->apiUrl['path'] . $path;


### PR DESCRIPTION
Due to recent fixes in the api this needs to be adjusted.